### PR TITLE
Event type filtering does not work correctly when types does not exist yet in database

### DIFF
--- a/src/test/java/io/gravitee/repository/EventRepositoryTest.java
+++ b/src/test/java/io/gravitee/repository/EventRepositoryTest.java
@@ -104,6 +104,16 @@ public class EventRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    public void searchByMissingType() throws Exception {
+        Page<Event> eventPage = eventRepository.search(
+                new EventCriteria.Builder().types(EventType.GATEWAY_STARTED).build(),
+                new PageableBuilder().pageNumber(0).pageSize(10).build());
+
+        assertEquals(0, eventPage.getTotalElements());
+        assertTrue(eventPage.getContent().isEmpty());
+    }
+
+    @Test
     public void searchByAPIId() throws Exception {
         Page<Event> eventPage = eventRepository.search(
                 new EventCriteria.Builder()

--- a/src/test/java/io/gravitee/repository/config/MockTestRepositoryConfiguration.java
+++ b/src/test/java/io/gravitee/repository/config/MockTestRepositoryConfiguration.java
@@ -266,6 +266,11 @@ public class MockTestRepositoryConfiguration {
                         .property(Event.EventProperties.API_ID.getValue(), Arrays.asList("api-1", "api-3"))
                         .build())).thenReturn(Arrays.asList(event4, event2, event1));
 
+        when(eventRepository.search(
+                new EventCriteria.Builder().types(EventType.GATEWAY_STARTED).build(),
+                new PageableBuilder().pageNumber(0).pageSize(10).build())).thenReturn(
+                        new io.gravitee.common.data.domain.Page<>(Collections.emptyList(), 0, 0, 0));
+
         return eventRepository;
     }
 


### PR DESCRIPTION
This closes https://github.com/gravitee-io/issues/issues/441