### PR TITLE
feat(idp): oauth idp could authorize users without email

### DIFF
--- a/src/test/java/io/gravitee/repository/IdentityProviderRepositoryTest.java
+++ b/src/test/java/io/gravitee/repository/IdentityProviderRepositoryTest.java
@@ -59,6 +59,7 @@ public class IdentityProviderRepositoryTest extends AbstractRepositoryTest {
         assertEquals("Gravitee.io AM Identity Provider", identityProvider.getDescription());
         assertFalse(identityProvider.isEnabled());
         assertEquals(IdentityProviderType.GRAVITEEIO_AM, identityProvider.getType());
+        assertNull(identityProvider.getEmailRequired());
 
         String condition = "{#jsonPath('$.email_verified')}";
 
@@ -95,6 +96,7 @@ public class IdentityProviderRepositoryTest extends AbstractRepositoryTest {
         identityProvider.setUpdatedAt(new Date(1439032010883L));
         identityProvider.setType(IdentityProviderType.GITHUB);
         identityProvider.setEnabled(true);
+        identityProvider.setEmailRequired(true);
 
         int nbIdentityProvidersBeforeCreation = identityProviderRepository.findAll().size();
         identityProviderRepository.create(identityProvider);
@@ -112,6 +114,7 @@ public class IdentityProviderRepositoryTest extends AbstractRepositoryTest {
         Assert.assertEquals("Invalid identity provider updatedAt.", identityProvider.getUpdatedAt(), identityProviderSaved.getUpdatedAt());
         Assert.assertEquals("Invalid identity provider type.", identityProvider.getType(), identityProviderSaved.getType());
         Assert.assertEquals("Invalid identity provider enabled.", identityProvider.isEnabled(), identityProviderSaved.isEnabled());
+        Assert.assertEquals("Invalid identity provider emailRequired.", identityProvider.getEmailRequired(), identityProviderSaved.getEmailRequired());
     }
 
     @Test
@@ -127,6 +130,7 @@ public class IdentityProviderRepositoryTest extends AbstractRepositoryTest {
         identityProvider.setUpdatedAt(new Date(1486771200000L));
         identityProvider.setType(IdentityProviderType.GOOGLE);
         identityProvider.setEnabled(true);
+        identityProvider.setEmailRequired(true);
 
         int nbIdentityProvidersBeforeUpdate = identityProviderRepository.findAll().size();
         identityProviderRepository.update(identityProvider);
@@ -144,6 +148,7 @@ public class IdentityProviderRepositoryTest extends AbstractRepositoryTest {
         Assert.assertEquals("Invalid identity provider updatedAt.", identityProvider.getUpdatedAt(), identityProviderUpdated.getUpdatedAt());
         Assert.assertEquals("Invalid identity provider type.", identityProvider.getType(), identityProviderUpdated.getType());
         Assert.assertEquals("Invalid identity provider enabled.", identityProvider.isEnabled(), identityProviderUpdated.isEnabled());
+        Assert.assertEquals("Invalid identity provider emailRequired.", identityProvider.getEmailRequired(), identityProviderUpdated.getEmailRequired());
     }
 
     @Test

--- a/src/test/java/io/gravitee/repository/config/mock/IdentityProviderRepositoryMock.java
+++ b/src/test/java/io/gravitee/repository/config/mock/IdentityProviderRepositoryMock.java
@@ -51,6 +51,7 @@ public class IdentityProviderRepositoryMock extends AbstractRepositoryMock<Ident
         when(newIdentityProvider.getCreatedAt()).thenReturn(new Date(1000000000000L));
         when(newIdentityProvider.getUpdatedAt()).thenReturn(new Date(1439032010883L));
         when(newIdentityProvider.getType()).thenReturn(IdentityProviderType.GITHUB);
+        when(newIdentityProvider.getEmailRequired()).thenReturn(true);
 
         final IdentityProvider identityProvider1 = new IdentityProvider();
         identityProvider1.setId("github");
@@ -68,6 +69,7 @@ public class IdentityProviderRepositoryMock extends AbstractRepositoryMock<Ident
         when(identityProviderUpdated.getUpdatedAt()).thenReturn(new Date(1486771200000L));
         when(identityProviderUpdated.getType()).thenReturn(IdentityProviderType.GOOGLE);
         when(identityProviderUpdated.isEnabled()).thenReturn(true);
+        when(identityProviderUpdated.getEmailRequired()).thenReturn(true);
 
         final IdentityProvider identityProvider3 = createMock();
 


### PR DESCRIPTION
Refactoring from 1.20.16 due to new idp management

fix gravitee-io/issues#2124